### PR TITLE
Updates for 0.9.x

### DIFF
--- a/psci.el
+++ b/psci.el
@@ -195,7 +195,7 @@ Relies on .psci file for determining the project's root folder."
 
 (defgroup psci nil "psci customisation group."
   :tag "psci"
-  :version "0.0.9"
+  :version "0.0.4"
   :group 'purescript
   :prefix "psci/")
 

--- a/psci.el
+++ b/psci.el
@@ -63,8 +63,10 @@
 (defvar psci/file-path "psci"
   "Path to the program used by `psci' function.")
 
-(defvar psci/arguments '("src/**/*.purs" "bower_components/purescript-*/src/**/*.purs")
-  "Commandline arguments to pass to `psci' function.")
+(defcustom psci/arguments '("src/**/*.purs" "bower_components/purescript-*/src/**/*.purs")
+  "Commandline arguments to pass to `psci' function."
+  :group 'psci
+  :type '(repeat string))
 
 (defvar psci/prompt "> "
   "The psci prompt.")

--- a/psci.el
+++ b/psci.el
@@ -5,7 +5,7 @@
 ;; Author: Antoine R. Dumont <eniotna.t AT gmail.com>
 ;; Maintainer: Antoine R. Dumont <eniotna.t AT gmail.com>
 ;; Version: 0.0.6
-;; Package-Requires: ((purescript-mode "13.10") (dash "2.9.0") (s "1.9.0") (f "0.17.1") (deferred "0.3.2"))
+;; Package-Requires: ((purescript-mode "13.10") (dash "2.9.0") (s "1.9.0") (f "0.17.1"))
 ;; Keywords: purescript psci repl major mode
 ;; URL: https://github.com/ardumont/emacs-psci
 
@@ -53,7 +53,6 @@
 (require 'purescript-mode)
 (require 's)
 (require 'f)
-(require 'deferred)
 
 ;; constants or variables
 


### PR DESCRIPTION
Not sure why such the ugly diff, but this has some updates that make psci usable with the 0.9 compiler.

The .psci file is no longer used and instead new files will only be picked up with a reset (no :load command anymore). 